### PR TITLE
Disabled conversation saving to DB to fix a bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 EXPOSE 3030
-CMD npm run dev
+CMD npm run start

--- a/databasing/database.js
+++ b/databasing/database.js
@@ -2,40 +2,74 @@ import pg from "pg";
 import db_config from "../secrets/db-config.json" with { type: "json" };
 
 // Create a new database connection
-export const pg_basepool = new pg.Pool({
-    host: "127.0.0.1", // use 127.0.0.1 if in dev environment, 172.23.0.1 before running docker build
-    port: 5432,
-    user: "francium-admin",
-    password: db_config.db_password,
-    database: "database-atlantis",
-})
+export const createBasePool = (host, database) => {
+    return new pg.Pool({
+        host: host, // use 127.0.0.1 if in dev environment, 172.23.0.1 before running docker build
+        port: 5432,
+        user: "francium-admin",
+        password: db_config.db_password,
+        database: database,
+    });
+}
 
 // For communicating with the Documents table.
-export const pgDocumentsConfig = {
-    pool: pg_basepool,
-    tableName: "simpleDocuments", // This is a table that stores documents, all configured below in the "columns" object.
-    collectionName: "documents_collection",
-    collectionTableName: "collections", // This is a table that stores the collection objects
-    columns: {
-        idColumnName: "id",
-        vectorColumnName: "vector",
-        contentColumnName: "content",
-        metadataColumnName: "metadata",
-    },
-    // distanceStrategy: 'cosine'
-};
+export const createPGDocumentConfig = (pool) => {
+    return {
+        pool: pool,
+        tableName: "simpleDocuments", // This is a table that stores documents, all configured below in the "columns" object.
+        collectionName: "documents_collection",
+        collectionTableName: "collections", // This is a table that stores the collection objects
+        columns: {
+            idColumnName: "id",
+            vectorColumnName: "vector",
+            contentColumnName: "content",
+            metadataColumnName: "metadata",
+        },
+        // distanceStrategy: 'cosine'
+    }
+}
+
+export const createPGConvoConfig = (pool) => {
+    return {
+        pool: pool,
+        tableName: "convohistory", // This is a table that stores documents, all configured below in the "columns" object.
+        collectionName: "convohistory_collection",
+        collectionTableName: "collections", // This is a table that stores the collection objects
+        columns: {
+            idColumnName: "id",
+            vectorColumnName: "vector",
+            contentColumnName: "content",
+            metadataColumnName: "metadata",
+        },
+        // distanceStrategy: 'cosine'
+    }
+}
+
+// export const pgDocumentsConfig = {
+//     pool: pg_basepool,
+//     tableName: "simpleDocuments", // This is a table that stores documents, all configured below in the "columns" object.
+//     collectionName: "documents_collection",
+//     collectionTableName: "collections", // This is a table that stores the collection objects
+//     columns: {
+//         idColumnName: "id",
+//         vectorColumnName: "vector",
+//         contentColumnName: "content",
+//         metadataColumnName: "metadata",
+//     },
+//     // distanceStrategy: 'cosine'
+// };
 
 // For communicating with the Conversation History table.
-export const pgConversationConfig = {
-    pool: pg_basepool,
-    tableName: "convohistory", // This is a table that stores documents, all configured below in the "columns" object.
-    collectionName: "convohistory_collection",
-    collectionTableName: "collections", // This is a table that stores the collection objects
-    columns: {
-        idColumnName: "id",
-        vectorColumnName: "vector",
-        contentColumnName: "content",
-        metadataColumnName: "metadata",
-    },
-    // distanceStrategy: 'cosine'
-};
+// export const pgConversationConfig = {
+//     pool: pg_basepool,
+//     tableName: "convohistory", // This is a table that stores documents, all configured below in the "columns" object.
+//     collectionName: "convohistory_collection",
+//     collectionTableName: "collections", // This is a table that stores the collection objects
+//     columns: {
+//         idColumnName: "id",
+//         vectorColumnName: "vector",
+//         contentColumnName: "content",
+//         metadataColumnName: "metadata",
+//     },
+//     // distanceStrategy: 'cosine'
+// };

--- a/hello.js
+++ b/hello.js
@@ -1,0 +1,7 @@
+const validate = true;
+
+const hello = (
+    validate ? "Yes" : "No"
+)
+
+console.log(hello) // Output: Yes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-test",
-  "version": "1.0.0",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-test",
-      "version": "1.0.0",
+      "version": "0.2.5",
       "license": "ISC",
       "dependencies": {
         "@langchain/community": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "dev": "node server.js"
+    "start": "node server.js",
+    "dev": "npx nodemon server.js"
   },
   "keywords": [],
   "author": "",

--- a/routes/francium.js
+++ b/routes/francium.js
@@ -138,6 +138,19 @@ router.post('/', async (req, res) => {
 
 // TODO: consider implementing streaming here next time
 
+// POST request for discord.js to inialize a conversation with provided context
+router.put('/discord-init', async (req, res) => {
+    // If context is given, override server's saved context.
+    // So, when initiating a conversation, pass in the context
+    if (req.body.context) {
+        prev_messages = req.body.context;
+    }
+
+    console.log("Discord initialized:\n", prev_messages);
+
+    res.json(prev_messages);
+})
+
 // TODO: add querying api for pgvector here
 router.get('/pgvector', async (req, res) => {
     try {

--- a/routes/francium.js
+++ b/routes/francium.js
@@ -48,7 +48,7 @@ let prev_messages = []; // This stores the previous messages as a string.
 // Generate a uid for the current conversation.
 // This will be refreshed every time the server is restarted.
 // This helps the server track the current conversation.
-const conversationID = uuidv4();
+// const conversationID = uuidv4();
 
 //------------------------------------------------- MARK: Start defining routes------------------------------------------------------------------------
 // TODO: Add better error handling here

--- a/routes/francium.js
+++ b/routes/francium.js
@@ -51,6 +51,7 @@ let prev_messages = ''; // This stores the previous messages as a string.
 const conversationID = uuidv4();
 
 //------------------------------------------------- MARK: Start defining routes------------------------------------------------------------------------
+// TODO: Add better error handling here
 router.post('/', async (req, res) => {
     try {
         // Receive incoming data
@@ -61,10 +62,10 @@ router.post('/', async (req, res) => {
         const pgvectorDocumentStore = await PGVectorStore.initialize(embeddings, pgDocumentsConfig);
 
         // Fetch old relevant conversation history
-        const convohistQueryResults = await pgvectorConvoStore.similaritySearch(
-            userMessage,
-            5
-        );
+        // const convohistQueryResults = await pgvectorConvoStore.similaritySearch(
+        //     userMessage,
+        //     5
+        // );
 
         // Fetch any relevant data from knowledge base
         // TODO: You should probably do some embedding here
@@ -75,6 +76,7 @@ router.post('/', async (req, res) => {
             filter, // this is the optional filter to use.
             // you may wish to use callbacks here as well, to handle success.
         );
+        console.log("document query finished!")
 
         //TODO: turn this into a function in a seperate file
         // Format the results into a readable format
@@ -83,10 +85,10 @@ router.post('/', async (req, res) => {
             documentArr.push(document.pageContent);
         };
         // Format the results into a readable format
-        const convohistArr = [];
-        for await (const item of convohistQueryResults) {
-            convohistArr.push(item.pageContent);
-        };
+        // const convohistArr = [];
+        // for await (const item of convohistQueryResults) {
+        //     convohistArr.push(item.pageContent);
+        // };
 
         // console.log(documentQueryResults);
 
@@ -124,6 +126,7 @@ router.post('/', async (req, res) => {
             [current_conversation],
             { ids: [conversationID] }
         )
+        console.log("Conversation refreshed successfully");
 
         // console.log(prev_messages);
 
@@ -133,6 +136,7 @@ router.post('/', async (req, res) => {
 
     } catch (err) {
         console.log(err);
+        res.status(500).json({ error: 'An error occurred.' });
     }
 });
 

--- a/routes/francium.js
+++ b/routes/francium.js
@@ -18,13 +18,14 @@ const router = express.Router();
 // MARK: Set up Ollama related stuff
 const ollama = new Ollama({
     baseUrl: 'http://host.docker.internal:11434',
-    model: 'aegis:v0.4L',
-    keepAlive: '30m'
+    model: 'aegis:v0.5',
+    keepAlive: -1
 });
 
 // Use an embedding LLM to create embeds
 const embeddings = new OllamaEmbeddings({
     baseUrl: "http://host.docker.internal:11434",
+    keepAlive: -1
 })
 
 // MARK: Create a simple prompt template
@@ -62,7 +63,7 @@ router.post('/', async (req, res) => {
             "database-atlantis"
         )
 
-        const pgvectorConvoStore = await PGVectorStore.initialize(embeddings, createPGConvoConfig(pg_basepool));
+        // const pgvectorConvoStore = await PGVectorStore.initialize(embeddings, createPGConvoConfig(pg_basepool));
         const pgvectorDocumentStore = await PGVectorStore.initialize(embeddings, createPGDocumentConfig(pg_basepool));
 
         // Fetch old relevant conversation history
@@ -110,30 +111,30 @@ router.post('/', async (req, res) => {
         prev_messages.push(formatMessage('You', result));
         
         // Prepare a conversation document to be stored
-        const current_conversation = {
-            pageContent: prev_messages.join('\n'),
-            metadata: {
-                date: Date.now(),
-            }
-        }
+        // const current_conversation = {
+        //     pageContent: prev_messages.join('\n'),
+        //     metadata: {
+        //         date: Date.now(),
+        //     }
+        // }
 
         // Check if the document already exists in the pgvector database:
         // The first time a new conversation is started, there should be an error...
-        try {
-            await pgvectorConvoStore.delete({ ids: [conversationID] });
-            console.log("Conversation deleted successfully...");
-        } catch (e) {
-            console.log(e, "\nConversation does not exist yet; Creating new one...");
-        }
-        // Add the current conversation if it exists, or create a new one.
-        await pgvectorConvoStore.addDocuments(
-            [current_conversation],
-            { ids: [conversationID] }
-        )
-        console.log("Conversation refreshed successfully");
+        // try {
+        //     await pgvectorConvoStore.delete({ ids: [conversationID] });
+        //     console.log("Conversation deleted successfully...");
+        // } catch (e) {
+        //     console.log(e, "\nConversation does not exist yet; Creating new one...");
+        // }
+        // // Add the current conversation if it exists, or create a new one.
+        // await pgvectorConvoStore.addDocuments(
+        //     [current_conversation],
+        //     { ids: [conversationID] }
+        // )
+        // console.log("Conversation refreshed successfully");
 
         // console.log(prev_messages);
-
+        console.log("Sending response data...");
         pg_basepool.end(); // Ends the pool
 
         res.json({

--- a/testapi.js
+++ b/testapi.js
@@ -7,7 +7,8 @@ while (true) {
     const data = await fetch("http://host.docker.internal:3030/francium", {
         method: "POST",
         body: JSON.stringify({
-            message: input
+            message: input,
+            context: "bababa"
         }),
         headers: {
             "Content-Type": "application/json"

--- a/testdiscapi.js
+++ b/testdiscapi.js
@@ -1,0 +1,29 @@
+import readline from 'readline-sync';
+
+const data = await fetch('http://localhost:3030/francium/discord-init', {
+    method: "PUT",
+    body: JSON.stringify({
+        message: "hello",
+        context: "bababa"
+    }),
+    headers: {
+        "Content-Type": "application/json"
+    }
+})
+
+const data2 = await fetch('http://localhost:3030/francium/discord-init', {
+    method: "PUT",
+    body: JSON.stringify({
+        message: "byebye",
+        context: "bibibibi"
+    }),
+    headers: {
+        "Content-Type": "application/json"
+    }
+})
+
+const dataJSON = await data.json();
+console.log(dataJSON)
+
+const dataJSON2 = await data2.json();
+console.log(dataJSON2)


### PR DESCRIPTION
Bug: Embed LLM does not have a big enough context window to handle the increasingly lengthy current convo history

Hence, I disabled it for now, and will find better workarounds to resolve this issue. For now, the conversation history will not be stored on the database.

I will look into better ways to store conversations too.

Lastly, this revision has been loaded with the latest version of Aegis, v0.5